### PR TITLE
Teach server how to act as a client

### DIFF
--- a/lib/osc-ruby/server.rb
+++ b/lib/osc-ruby/server.rb
@@ -18,7 +18,7 @@ module OSC
     end
 
     def send(msg, address, port)
-      @socket.send msg, 0, address, port
+      @socket.send msg.encode, 0, address, port
     end
 
     def add_method( address_pattern, &proc )

--- a/lib/osc-ruby/server.rb
+++ b/lib/osc-ruby/server.rb
@@ -17,6 +17,10 @@ module OSC
       @socket.close
     end
 
+    def send(msg, address, port)
+      @socket.send msg, 0, address, port
+    end
+
     def add_method( address_pattern, &proc )
       matcher = AddressPattern.new( address_pattern )
 


### PR DESCRIPTION
This essentially allows the server to act as a client. This is extremely
useful in the situations where you wish to send a message to an external
OSC server and then listen to responses from it (which it sends back
down the UDPSocket).

For example, when communicating with the SuperCollider server, it's
useful to send the "/notify" command, which then allows you to receive
information from the server.

```
server = OSC::Server.new 5440

server.add_method "/done" do |m|
  puts "done!"
end

Thread.new {server.run}

scsynth_port = 6555
server.send(OSC::Message.new("/notify", 1).encode, "127.0.0.1", scsynth_port))
```
