### PR TITLE
Add support for nonstandard double argument type:

### DIFF
--- a/lib/osc-ruby/osc_packet.rb
+++ b/lib/osc-ruby/osc_packet.rb
@@ -45,10 +45,11 @@ module OSC
     def initialize( string )
       @packet = NetworkPacket.new( string )
 
-      @types = { "i" => lambda{  OSCInt32.new(   get_int32 ) },
-                 "f" => lambda{  OSCFloat32.new( get_float32 ) },
-                 "s" => lambda{  OSCString.new(  get_string ) },
-                 "b" => lambda{  OSCBlob.new(    get_blob )}
+      @types = { "i" => lambda{  OSCInt32.new(    get_int32 ) },
+                 "f" => lambda{  OSCFloat32.new(  get_float32 ) },
+                 "d" => lambda{  OSCDouble64.new( get_double64 )},
+                 "s" => lambda{  OSCString.new(   get_string ) },
+                 "b" => lambda{  OSCBlob.new(     get_blob )}
                 }
     end
 
@@ -108,6 +109,12 @@ module OSC
 
     def get_float32
       f = @packet.getn(4).unpack('g')[0]
+      @packet.skip_padding
+      f
+    end
+
+    def get_double64
+      f = @packet.getn(8).unpack('G')[0]
       @packet.skip_padding
       f
     end

--- a/lib/osc-ruby/osc_types.rb
+++ b/lib/osc-ruby/osc_types.rb
@@ -8,7 +8,12 @@ module OSC
 
   class OSCFloat32 < OSCArgument
     def tag() 'f' end
-    def encode() [@val].pack('g').force_encoding("BINARY") end 
+    def encode() [@val].pack('g').force_encoding("BINARY") end
+  end
+
+  class OSCDouble64 < OSCArgument
+    def tag() 'd' end
+    def encode() [@val].pack('G').force_encoding("BINARY") end
   end
 
   class OSCString < OSCArgument


### PR DESCRIPTION
'd' => 64 bit ("double") IEEE 754 floating point number

See http://opensoundcontrol.org/spec-1_0 for a list of the nonstandard types.

This type is used by the SuperCollider server.
