### PR TITLE
Raise "unknown OSC type" when an unknown OSC tag is encountered.

### DIFF
--- a/lib/osc-ruby/osc_packet.rb
+++ b/lib/osc-ruby/osc_packet.rb
@@ -93,7 +93,9 @@ module OSC
         args = []
 
         tags.scan(/./) do | tag |
-          args << @types[tag].call
+          type_handler = @types[tag]
+          raise "Unknown OSC type: #{tag}" unless type_handler
+          args << type_handler.call
         end
         args
       end


### PR DESCRIPTION
Current behaviour results in a mystical error message:

`undefined method`call' for nil:NilClass (NoMethodError)`

This patch makes that error slightly more readable and understandable.
