### PR TITLE
Add broadcast client class

### DIFF
--- a/lib/osc-ruby.rb
+++ b/lib/osc-ruby.rb
@@ -16,5 +16,6 @@ require 'osc-ruby/address_pattern'
 # now we gettin fancy
 require 'osc-ruby/server'
 require 'osc-ruby/client'
+require 'osc-ruby/broadcast_client'
 
 

--- a/lib/osc-ruby/broadcast_client.rb
+++ b/lib/osc-ruby/broadcast_client.rb
@@ -1,0 +1,18 @@
+module OSC
+  class BroadcastClient
+
+    BROADCAST_ADDRESS = '<broadcast>'
+
+    attr_reader :port
+
+    def initialize(port)
+      @port = port
+      @so = UDPSocket.new
+      @so.setsockopt Socket::SOL_SOCKET, Socket::SO_BROADCAST, true
+    end
+
+    def send(mesg)
+      @so.send(mesg.encode, 0, BROADCAST_ADDRESS, @port)
+    end
+  end
+end


### PR DESCRIPTION
I added a class to create broadcast clients. The default client code will not accept the `<broadcast>` network address, it returns a `E_ACCESS` error.
I prefered to create a separate class to deal easily with additional functionality and avoid any compatibility risk, although the modification is so simple it should be working just fine.
