### PR TITLE
Specify broadcast interface by passing in local IP

### DIFF
--- a/lib/osc-ruby/broadcast_client.rb
+++ b/lib/osc-ruby/broadcast_client.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 module OSC
   class BroadcastClient
 
@@ -5,10 +7,14 @@ module OSC
 
     attr_reader :port
 
-    def initialize(port)
+    def initialize(port, local_ip = nil)
       @port = port
       @so = UDPSocket.new
       @so.setsockopt Socket::SOL_SOCKET, Socket::SO_BROADCAST, true
+      if local_ip
+        @so.setsockopt Socket::IPPROTO_IP, Socket::IP_MULTICAST_IF, IPAddr.new(local_ip).hton
+        @so.bind(local_ip, 0)
+      end
     end
 
     def send(mesg)


### PR DESCRIPTION
This lets you send multicast packets from a network interface other than the primary interface by passing in an IP address for the local interface.