### PR TITLE
Fix parens for warning in Ruby 2.6.5

### DIFF
--- a/lib/osc-ruby/network_packet.rb
+++ b/lib/osc-ruby/network_packet.rb
@@ -12,7 +12,7 @@ module OSC
       @str.length - @index
     end
 
-    def eof? ()
+    def eof?()
       rem <= 0
     end
 


### PR DESCRIPTION
Small chance to fix an extra space in the method definition - `def eof? ()` => `def eof?()` (without space)

Fixes the warning

```
/.gem/ruby/2.6.5/gems/osc-ruby-1.1.3/lib/osc-ruby/network_packet.rb:15: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
```

Arguably the empty parens for methods like this could be removed  but that's more of a stylistic thing across the whole project.