### PR TITLE
removing an unnecessary argument passed to Message.new

### DIFF
--- a/lib/osc-ruby/message.rb
+++ b/lib/osc-ruby/message.rb
@@ -6,7 +6,7 @@ module OSC
     attr_accessor :ip_port
 
     def self.new_with_time(address, time, tags=nil, *args)
-      message = new(address, tags, *args)
+      message = new(address, *args)
       message.time = time
       message
     end


### PR DESCRIPTION
This is not a significant issue right now, but future modifications may cause it to emerge as a concern.

This is slightly related to https://github.com/aberant/osc-ruby/issues/21